### PR TITLE
Does no longer handle transactions in parallel

### DIFF
--- a/waves_gateway/service/transaction_polling_service.py
+++ b/waves_gateway/service/transaction_polling_service.py
@@ -166,12 +166,8 @@ class TransactionPollingService(greenlet.Greenlet):
         self._polling_state_storage.set_polling_state(self._polling_state)
 
     def _handle_transactions(self, transactions: List[Transaction]) -> None:
-        handle_task_group = pool.Group()
-
         for tr in transactions:
-            handle_task_group.spawn(lambda: self._handle_transaction(tr))
-
-        handle_task_group.join(raise_error=True)
+            self._handle_transaction(tr)
 
     def _iteration(self):
         """


### PR DESCRIPTION
Parallel transaction handling seems to lead to strange issues.
This resets the behavior, so that transactions are processed in order.