### PR TITLE
Don't generate gateway fee receiver for zero fee configurations

### DIFF
--- a/tests/service/test_coin_transaction_consumer.py
+++ b/tests/service/test_coin_transaction_consumer.py
@@ -225,3 +225,80 @@ class CoinTransactionConsumerImplTestSingleReceiver(TestCase):
         self._map_storage.get_waves_address_by_coin_address.assert_called_once_with(gateway_coin_address)
         self._attempt_service.continue_transaction_attempt_list.assert_not_called()
         self._attempt_list_storage.safely_save_attempt_list.assert_called_once_with(attempt_list)
+
+
+class CoinTransactionConsumerImplTestSingleReceiverNoGwFee(TestCase):
+    def setUp(self):
+        self._waves_standard_fee = 10000
+        self._coin_standard_fee = 10111
+        self._gateway_managed_receiver = TransactionReceiver('826323', 7710475)
+        self._not_gateway_managed_receiver = TransactionReceiver('871263', 9992323)
+        self._wallet_storage = MagicMock(spec=WalletStorage)
+        self._coin_chain_query_service = MagicMock(spec=ChainQueryService)
+        self._gateway_address = '7625897'
+        self._gateway_coin_holder_receiver = TransactionReceiver(self._gateway_address, 6758)
+        self._map_storage = MagicMock()
+        self._logger = MagicMock()
+        self._waves_transaction_storage = MagicMock()
+        self._gateway_waves_address = "jshdj"
+        self._gateway_owner_address = '263587234'
+        self._attempt_service = MagicMock()
+        self._fee_service = MagicMock()
+        self._gateway_fee = 0
+        self._gateway_pywaves_address = MagicMock()
+        self._gateway_pywaves_address.address = self._gateway_waves_address
+        self._attempt_list_storage = MagicMock()
+
+        self._coin_transaction_consumer_impl = CoinTransactionConsumerImpl(
+            attempt_service=cast(TransactionAttemptListService, self._attempt_service),
+            gateway_coin_address=self._gateway_address,
+            map_storage=cast(MapStorage, self._map_storage),
+            logger=cast(Logger, self._logger),
+            gateway_waves_address=self._gateway_waves_address,
+            gateway_owner_address=self._gateway_owner_address,
+            fee_service=cast(FeeService, self._fee_service),
+            only_one_transaction_receiver=True,
+            gateway_pywaves_address=cast(pywaves.Address, self._gateway_pywaves_address),
+            attempt_list_storage=cast(TransactionAttemptListStorage, self._attempt_list_storage))
+
+        self._fee_service.get_coin_fee.return_value = self._coin_standard_fee
+        self._fee_service.get_gateway_fee.return_value = self._gateway_fee
+        self._fee_service.get_waves_fee.return_value = self._waves_standard_fee
+
+    @patch('datetime.datetime', autospec=True)
+    def test_handle_transaction_only_one_receiver(self, mock_datetime: MagicMock):
+        now = MagicMock()
+        mock_datetime.utcnow.return_value = now
+        gateway_coin_address = self._gateway_managed_receiver.address
+        dst_waves_address = '039769'
+        incoming_transaction = Transaction(tx='723968', receivers=[self._gateway_managed_receiver])
+
+        amount_after_fees = self._gateway_managed_receiver.amount - self._coin_standard_fee
+
+        attempts = [
+            TransactionAttempt(
+                sender=gateway_coin_address,
+                currency="coin",
+                fee=self._coin_standard_fee,
+                receivers=[TransactionAttemptReceiver(address=self._gateway_address, amount=amount_after_fees)]),
+            TransactionAttempt(
+                sender=self._gateway_waves_address,
+                fee=self._waves_standard_fee,
+                currency="waves",
+                receivers=[TransactionAttemptReceiver(address=dst_waves_address, amount=amount_after_fees)])
+        ]
+
+        trigger = AttemptListTrigger(tx=incoming_transaction.tx, currency="coin", receiver=0)
+
+        attempt_list = TransactionAttemptList(trigger=trigger, attempts=attempts, created_at=now, last_modified=now)
+
+        self._attempt_list_storage.find_by_trigger.return_value = None
+        self._map_storage.get_waves_address_by_coin_address.return_value = dst_waves_address
+
+        self._coin_transaction_consumer_impl.handle_transaction(incoming_transaction)
+
+        self._attempt_list_storage.find_by_trigger.assert_any_call(
+            AttemptListTrigger(tx=incoming_transaction.tx, receiver=0, currency="coin"))
+        self._map_storage.get_waves_address_by_coin_address.assert_called_once_with(gateway_coin_address)
+        self._attempt_service.continue_transaction_attempt_list.assert_not_called()
+        self._attempt_list_storage.safely_save_attempt_list.assert_called_once_with(attempt_list)


### PR DESCRIPTION
Currently when `gateway_fee=0`, the receiver (with `amount=0`) destined to the owner account is still generated. In multi-input-and-output coins this probably isn't an error, but for `only_one_transaction_receiver=True` this can be an error (zero amount transaction). And even if zero amount send is valid, it would still end up wasting one extra `coin_fee` on it.

This pull request updates the receiver generation logic to only generate the owner output/tx/receiver when the `gateway_fee > 0`.