### PR TITLE
Fix HTTP redirects to /static/index.html

### DIFF
--- a/waves_gateway/controller/flask_rest_controller.py
+++ b/waves_gateway/controller/flask_rest_controller.py
@@ -72,9 +72,9 @@ class FlaskRestController(object):
             lambda attempt_list_id: self._get_attempt_list_by_id(attempt_list_id),
             methods=['GET'])
 
-        self._add_url_rule('/', 'redirect', lambda: flask_module.redirect('static/'), methods=['GET'])
+        self._add_url_rule('/', 'redirect', lambda: flask_module.redirect('/static/'), methods=['GET'])
 
-        self._add_url_rule('/static/', 'index', lambda: flask_module.redirect('static/index.html'), methods=['GET'])
+        self._add_url_rule('/static/', 'index', lambda: flask_module.redirect('/static/index.html'), methods=['GET'])
 
         self._add_url_rule(
             '/api/v1/public-config',


### PR DESCRIPTION
Currently when opening `http://localhost:5000/` in the browser, the app redirects to `http://localhost:5000/static/static/index.html`, which returns _HTTP 404_ (note the double _static_ path component).

This PR fixes the redirects, by using absolute paths in the redirects, instead of relative ones.